### PR TITLE
fix compile run_sse4 on macos

### DIFF
--- a/src/all.h
+++ b/src/all.h
@@ -1,5 +1,6 @@
 #include "common.h"
 #include <utils/bits.cpp>
+#include <errno.h>
 #include "fixed-memcmp.cpp"
 #include "scalar.cpp"
 #include "swar64-strstr-v2.cpp"


### PR DESCRIPTION
In file included from src/speedup.cpp:14:
src/application_base.cpp:73:70: fatal error: use of undeclared identifier 'errno'
        const std::string msg = prefix + ": " + std::string(strerror(errno));

